### PR TITLE
Fixed small typo that caused a bug

### DIFF
--- a/CastleDBGen/CSharpWriter.cs
+++ b/CastleDBGen/CSharpWriter.cs
@@ -128,7 +128,7 @@ namespace CastleDBGen
                             classStr += string.Format("{0}{1} = uint.Parse(value.Property(\"{1}\").Value.ToString());\r\n", GetTabstring(tabDepth + 1), col.Name);
                             break;
                         case CastleType.Float:
-                            classStr += string.Format("{0}{1} = float.Parse(value.Property(\"{1}\").Value.ToString());r\n", GetTabstring(tabDepth + 1), col.Name);
+                            classStr += string.Format("{0}{1} = float.Parse(value.Property(\"{1}\").Value.ToString());\r\n", GetTabstring(tabDepth + 1), col.Name);
                             break;
                         case CastleType.Integer:
                             classStr += string.Format("{0}{1} = int.Parse(value.Property(\"{1}\").Value.ToString());\r\n", GetTabstring(tabDepth + 1), col.Name);

--- a/CastleDBGen/CSharpWriter.cs
+++ b/CastleDBGen/CSharpWriter.cs
@@ -77,6 +77,9 @@ namespace CastleDBGen
                         case CastleType.Integer:
                             classStr += string.Format(ASProperty, "int", column.Name, GetTabstring(tabDepth + 0));
                             break;
+						case CastleType.Float:
+							classStr += string.Format(ASProperty, "float", column.Name, GetTabstring(tabDepth + 0));
+							break;
                         case CastleType.Layer:
                             errors.Add(string.Format("Sheet {0}, type {1} unsupported", column.Name, column.TypeID.ToString()));
                             break;


### PR DESCRIPTION
That small typo wrote an "r" character after each float value used in the "load" function and floats are now created as properties inside the class. 